### PR TITLE
Remove `prototype` from namespace

### DIFF
--- a/www/InAppRatingsReview.js
+++ b/www/InAppRatingsReview.js
@@ -3,7 +3,7 @@ function InAppRatingsReview() {
 
 }
 
-InAppRatingsReview.prototype.requestReview = function (successCallback, errorCallback) {
+InAppRatingsReview.requestReview = function (successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, 'InAppRatingsReview', 'requestReview', []);
 };
 


### PR DESCRIPTION
Including `prototype` in the namespace is unnecessary and counter to the README instructions. 

Big thanks for creating this plugin @jay2503 